### PR TITLE
Added abstract to pod

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangesFromYaml.pm
+++ b/lib/Dist/Zilla/Plugin/ChangesFromYaml.pm
@@ -27,6 +27,10 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=head1 NAME
+
+Dist::Zilla::Plugin::ChangesFromYaml - convert Changes from YAML to CPAN::Changes::Spec format
+
 =head1 SYNOPSIS
 
 In your 'dist.ini':


### PR DESCRIPTION
I've added an abstract to your pod. MetaCPAN wasn't displaying your module right in search results, because it couldn't find an abstract in the pod.

Cheers,
Neil
