### PR TITLE
Make tests less strict about trailing empty line

### DIFF
--- a/t/01basic.t
+++ b/t/01basic.t
@@ -8,6 +8,7 @@ my $tzil = Builder->from_config( { dist_root => 'corpus/DZT' } );
 $tzil->build;
 
 my $contents = $tzil->slurp_file('build/Changes');
+$contents =~ s/^$//m;
 
 is( $contents, <<'CHANGES', "Changes got converted correctly" );
 0.37 Fri Oct 25 21:46:59 MYT 2013
@@ -21,5 +22,4 @@ is( $contents, <<'CHANGES', "Changes got converted correctly" );
 
 0.35 Mon May 27 14:23:42 PDT 2013
  - Forgot to merge doc changes from CarlosLima++
-
 CHANGES

--- a/t/02dateformat.t
+++ b/t/02dateformat.t
@@ -9,6 +9,7 @@ my $tzil = Builder->from_config( { dist_root => 'corpus/DZT2' } );
 $tzil->build;
 
 my $contents = $tzil->slurp_file('build/Changes');
+$contents =~ s/^$//m;
 
 is( $contents, <<'CHANGES', "Changes got converted correctly" );
 0.37 2013-10-25 21:46:59 +0800
@@ -22,5 +23,4 @@ is( $contents, <<'CHANGES', "Changes got converted correctly" );
 
 0.35 2013-05-27 14:23:42 -0700
  - Forgot to merge doc changes from CarlosLima++
-
 CHANGES


### PR DESCRIPTION
see issue #2

I guess since the empty line is not really important, the test can ignore it?
